### PR TITLE
Add unocss-preset-fluentui to community presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ A curated list of awesome things related to <a href='https://github.com/unocss/u
 - [unocss-preset-better-breakpoints](https://github.com/ZaneL1u/unocss-preset-better-breakpoints) ![GitHub Repo stars](https://img.shields.io/github/stars/ZaneL1u/unocss-preset-better-breakpoints) - Better breakpoints presets for UnoCSS. By [@ZaneL1u](https://github.com/ZaneL1u).
 - [unocss-preset-nuxt-ui](https://github.com/lehuuphuc/unocss-preset-nuxt-ui) ![GitHub Repo stars](https://img.shields.io/github/stars/lehuuphuc/unocss-preset-nuxt-ui) - The preset that makes using UnoCSS with Nuxt UI effortless. By [@lehuuphuc](https://github.com/lehuuphuc).
 - [unocss-preset-utopia-core](https://github.com/azbestoid/unocss-preset-utopia-core) ![GitHub Repo stars](https://img.shields.io/github/stars/azbestoid/unocss-preset-utopia-core) - Fluid typography and spacing using Utopia.fyi. By [@azbestoid](https://github.com/azbestoid).
+- [unocss-preset-fluentui](https://github.com/CollaStack/unocss-preset-fluentui) ![GitHub Repo stars](https://img.shields.io/github/stars/CollaStack/unocss-preset-fluentui) - Fluent UI design tokens as utility classes for UnoCSS. By [@CollaStack](https://github.com/CollaStack).
 
 ### Frameworks
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ A curated list of awesome things related to <a href='https://github.com/unocss/u
 - [unocss-preset-better-breakpoints](https://github.com/ZaneL1u/unocss-preset-better-breakpoints) ![GitHub Repo stars](https://img.shields.io/github/stars/ZaneL1u/unocss-preset-better-breakpoints) - Better breakpoints presets for UnoCSS. By [@ZaneL1u](https://github.com/ZaneL1u).
 - [unocss-preset-nuxt-ui](https://github.com/lehuuphuc/unocss-preset-nuxt-ui) ![GitHub Repo stars](https://img.shields.io/github/stars/lehuuphuc/unocss-preset-nuxt-ui) - The preset that makes using UnoCSS with Nuxt UI effortless. By [@lehuuphuc](https://github.com/lehuuphuc).
 - [unocss-preset-utopia-core](https://github.com/azbestoid/unocss-preset-utopia-core) ![GitHub Repo stars](https://img.shields.io/github/stars/azbestoid/unocss-preset-utopia-core) - Fluid typography and spacing using Utopia.fyi. By [@azbestoid](https://github.com/azbestoid).
-- [unocss-preset-fluentui](https://github.com/CollaStack/unocss-preset-fluentui) ![GitHub Repo stars](https://img.shields.io/github/stars/CollaStack/unocss-preset-fluentui) - Fluent UI design tokens as utility classes for UnoCSS. By [@CollaStack](https://github.com/CollaStack).
+- [unocss-preset-fluentui](https://github.com/CollaStack/unocss-preset-fluentui) ![GitHub Repo stars](https://img.shields.io/github/stars/CollaStack/unocss-preset-fluentui) - Fluent UI design tokens as utility classes for UnoCSS. By [@link-duan](https://github.com/link-duan).
 
 ### Frameworks
 


### PR DESCRIPTION
## Summary

- Add [unocss-preset-fluentui](https://github.com/CollaStack/unocss-preset-fluentui) to the Community Presets section.

## About the preset

A UnoCSS preset that maps [Fluent UI design tokens](https://github.com/microsoft/fluentui/tree/master/packages/tokens) to utility classes, bringing the Microsoft Fluent design language to atomic CSS workflows.

- Published on npm: [`unocss-preset-fluentui`](https://www.npmjs.com/package/unocss-preset-fluentui)
- Supports colors, border radius, typography, shadows, spacing, z-index, and animation tokens
- Works with `FluentProvider` for runtime theme switching